### PR TITLE
add ability to build models with dev/test environment credentials

### DIFF
--- a/src/Constructor.php
+++ b/src/Constructor.php
@@ -22,12 +22,13 @@ class Constructor
     protected static $map  = [];
     protected static $docs = [];
 
-    public static function buildModels($tenant, $username, $token)
+    public static function buildModels($tenant, $username, $token, $environment='production')
     {
         static::$sdk = SDK::instance($tenant, [
             'username'    => $username,
             'token'       => $token,
             'offline_map' => false,
+            'environment' => $environment,
         ]);
 
         static::line('+------------------------------');


### PR DESCRIPTION
The build Models had no support for setting an environment in the SDK. Once you start developing you might only have a testing environment. So we extended this method to support an environment setting.